### PR TITLE
Fix - 프로필 카드에서 id 제거 후 사용되지 않는 변수로 인한 lint 에러 제거

### DIFF
--- a/components/home/ProfileCard.tsx
+++ b/components/home/ProfileCard.tsx
@@ -11,7 +11,10 @@ interface ProfileCardProps {
 }
 
 export default function ProfileCard({ profile }: ProfileCardProps) {
-  const { code, updatedAt, image, ...profileTextValues } = profile;
+  // 타입 안정성을 위해 delete가 아닌 구조분해할당을 사용
+  // id는 구조분해할당으로 profileTextValues 제외 후에 사용되지 않기에 lint 에러 제거
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id, code, updatedAt, image, ...profileTextValues } = profile;
   const date = new Date(updatedAt);
   const year = date.getFullYear();
   const month = ('0' + (date.getMonth() + 1)).slice(-2);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,6 @@ const nextConfig = {
       },
     ];
   },
-  reactStrictMode: false,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 프로필 카드에서 id 제거 후 사용되지 않는 변수로 인한 lint 에러 제거

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
