### PR TITLE
Feature - 위키 생성 및 인증 질문 변경 시 옵션으로 이메일로 질문과 답변을 보내주는 기능 구현

### DIFF
--- a/components/@shared/header/Alarm.module.scss
+++ b/components/@shared/header/Alarm.module.scss
@@ -25,6 +25,7 @@
   }
 
   .bellButton {
+    cursor: pointer;
     @include mobile {
       img {
         height: 24px;

--- a/components/@shared/header/Alarm.tsx
+++ b/components/@shared/header/Alarm.tsx
@@ -75,9 +75,9 @@ export default function Alarm() {
   return (
     <div className={styles.alarmContainer}>
       <div className={classNames(styles.notificationCircle, { [styles.hidden]: !isRestNotification })} />
-      <button className={styles.bellButton} onClick={handleModalOpen}>
+      <div className={styles.bellButton} onClick={handleModalOpen}>
         <Image src={alarmIcon} alt={'알람 아이콘'} height={28} width={28} />
-      </button>
+      </div>
       <Portal isOpen={isModalOpen} onClose={onClose}>
         <NotificationModal onClose={onClose} notificationList={notificationList} onDelete={handleNotificationDelete} />
       </Portal>

--- a/components/myPage/CreateWikiForm.tsx
+++ b/components/myPage/CreateWikiForm.tsx
@@ -6,10 +6,8 @@ import ValidInput from '../@shared/Input/ValidInput';
 import { createProfile } from '@/apis/auth/createProfile';
 import { useSnackBar } from '@/contexts/SnackbarProvider';
 import { useAuth } from '@/contexts/AuthProvider';
-import { useState } from 'react';
 import { sendMail } from '@/utils/sendMail';
-
-// TODO: 위키 생성 폼이랑 위키 질문 변경 폼을 따로 만들어야 함
+import SendEmailInput from './SendEmailInput';
 
 export default function CreateWikiForm() {
   const { syncUserAuthState, user } = useAuth();
@@ -23,11 +21,11 @@ export default function CreateWikiForm() {
 
       if (response) {
         openSnackBar({ type: 'success', content: '위키 생성이 완료되었습니다.' });
-        const emailInput = event.target['email'];
-        if (emailInput.value) {
-          sendMail({ answer: securityAnswer, question: securityQuestion, name: user.name, email: emailInput.value });
+        const toEmailInput = event.target['toEmail'];
+        if (toEmailInput.value) {
+          sendMail({ answer: securityAnswer, question: securityQuestion, name: user.name, email: toEmailInput.value });
           // submit 시에만 필요한 input이기 때문에 불필요한 리렌더링 제거를 위해 따로 onChange 함수로 value를 관리하지 않기 때문
-          emailInput.value = '';
+          toEmailInput.value = '';
         }
         syncUserAuthState();
       } else {
@@ -52,9 +50,7 @@ export default function CreateWikiForm() {
         register={register.securityAnswer}
         placeholder={'답변을 입력해주세요'}
       />
-
-      <label className={'text-md'}>질문과 답변을 이메일로 받기</label>
-      <input className={'input'} type="email" name={'email'} placeholder={'비워두면 이메일은 가지 않아요..'} />
+      <SendEmailInput />
 
       <div className={styles.buttonWrapper}>
         <button className={'button'}>생성하기</button>

--- a/components/myPage/CreateWikiForm.tsx
+++ b/components/myPage/CreateWikiForm.tsx
@@ -6,21 +6,29 @@ import ValidInput from '../@shared/Input/ValidInput';
 import { createProfile } from '@/apis/auth/createProfile';
 import { useSnackBar } from '@/contexts/SnackbarProvider';
 import { useAuth } from '@/contexts/AuthProvider';
+import { useState } from 'react';
+import { sendMail } from '@/utils/sendMail';
 
 // TODO: 위키 생성 폼이랑 위키 질문 변경 폼을 따로 만들어야 함
 
 export default function CreateWikiForm() {
-  const { syncUserAuthState } = useAuth();
+  const { syncUserAuthState, user } = useAuth();
   const { openSnackBar } = useSnackBar();
   const { register, errors, handleSubmit } = useValidForm(['securityAnswer', 'securityQuestion']);
 
-  const handleFormSubmit: SubmitHandler<FormInputValues> = async formData => {
-    if (formData.securityAnswer && formData.securityQuestion) {
+  const handleFormSubmit: SubmitHandler<FormInputValues> = async (formData, event) => {
+    if (formData.securityAnswer && formData.securityQuestion && event && user) {
       const { securityAnswer, securityQuestion } = formData;
       const response = await createProfile({ securityAnswer, securityQuestion });
 
       if (response) {
         openSnackBar({ type: 'success', content: '위키 생성이 완료되었습니다.' });
+        const emailInput = event.target['email'];
+        if (emailInput.value) {
+          sendMail({ answer: securityAnswer, question: securityQuestion, name: user.name, email: emailInput.value });
+          // submit 시에만 필요한 input이기 때문에 불필요한 리렌더링 제거를 위해 따로 onChange 함수로 value를 관리하지 않기 때문
+          emailInput.value = '';
+        }
         syncUserAuthState();
       } else {
         openSnackBar({ type: 'error', content: '위키 생성에 실패하였습니다.' });
@@ -44,6 +52,9 @@ export default function CreateWikiForm() {
         register={register.securityAnswer}
         placeholder={'답변을 입력해주세요'}
       />
+
+      <label className={'text-md'}>질문과 답변을 이메일로 받기</label>
+      <input className={'input'} type="email" name={'email'} placeholder={'비워두면 이메일은 가지 않아요..'} />
 
       <div className={styles.buttonWrapper}>
         <button className={'button'}>생성하기</button>

--- a/components/myPage/SendEmailInput.tsx
+++ b/components/myPage/SendEmailInput.tsx
@@ -1,0 +1,8 @@
+export default function SendEmailInput() {
+  return (
+    <>
+      <label className={'text-md'}>질문과 답변을 받을 이메일</label>
+      <input className={'input'} type="email" name={'toEmail'} placeholder={'비워두면 이메일은 가지 않아요..'} />
+    </>
+  );
+}

--- a/components/myPage/UpdateSecurityQuizForm.tsx
+++ b/components/myPage/UpdateSecurityQuizForm.tsx
@@ -7,8 +7,8 @@ import { updateSecurityQuiz } from '@/apis/auth/updateSecurityQuiz';
 import { useSnackBar } from '@/contexts/SnackbarProvider';
 import { fetchWithTokenRefresh } from '@/apis/auth/fetchWithTokenRefresh';
 import { useAuth } from '@/contexts/AuthProvider';
-import { ChangeEvent, useState } from 'react';
 import { sendMail } from '@/utils/sendMail';
+import SendEmailInput from './SendEmailInput';
 interface UpdateSecurityQuizFormProps {
   code: string;
   currentSecurityQuestion: string;
@@ -42,11 +42,16 @@ export default function UpdateSecurityQuizForm({ code, currentSecurityQuestion }
 
         if (response) {
           openSnackBar({ type: 'success', content: '인증 퀴즈가 변경되었습니다.' });
-          const emailInput = event.target['email'];
-          if (emailInput.value) {
-            sendMail({ answer: securityAnswer, question: securityQuestion, name: user.name, email: emailInput.value });
+          const toEmailInput = event.target['toEmail'];
+          if (toEmailInput.value) {
+            sendMail({
+              answer: securityAnswer,
+              question: securityQuestion,
+              name: user.name,
+              email: toEmailInput.value,
+            });
             // submit 시에만 필요한 input이기 때문에 불필요한 리렌더링 제거를 위해 따로 onChange 함수로 value를 관리하지 않기 때문
-            emailInput.value = '';
+            toEmailInput.value = '';
           }
 
           setValue('currentSecurityAnswer', '');
@@ -86,10 +91,7 @@ export default function UpdateSecurityQuizForm({ code, currentSecurityQuestion }
         register={register.securityAnswer}
         placeholder={'새로운 답변을 입력해주세요'}
       />
-
-      <label className={'text-md'}>질문과 답변을 이메일로 받기</label>
-      <input className={'input'} type="email" name={'email'} placeholder={'비워두면 이메일은 가지 않아요..'} />
-
+      <SendEmailInput />
       <div className={styles.buttonWrapper}>
         <button className={'button'}>변경하기</button>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wikid",
       "version": "0.1.0",
       "dependencies": {
+        "@emailjs/browser": "^4.4.1",
         "@typescript-eslint/eslint-plugin": "^8.4.0",
         "antd": "^5.20.3",
         "classnames": "^2.5.1",
@@ -314,6 +315,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
+      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@emailjs/browser": "^4.4.1",
     "@typescript-eslint/eslint-plugin": "^8.4.0",
     "antd": "^5.20.3",
     "classnames": "^2.5.1",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -51,8 +51,7 @@ body {
 }
 
 .auth-container {
-  margin-top: 20vh;
-  padding: 0 10px;
+  padding: 12vw 10px 20vw;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/utils/sendMail.ts
+++ b/utils/sendMail.ts
@@ -1,0 +1,22 @@
+import emailjs from '@emailjs/browser';
+
+interface SendMailParams {
+  name: string;
+  question: string;
+  answer: string;
+  email: string;
+}
+
+export const sendMail = ({ answer, email, name, question }: SendMailParams) => {
+  emailjs.send(
+    `${process.env.NEXT_PUBLIC_EMAILJS_SERVICE_KEY}`,
+    `${process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_KEY}`,
+    {
+      name,
+      question,
+      answer,
+      email,
+    },
+    `${process.env.NEXT_PUBLIC_EMAILJS_PUBLIC_KEY}`,
+  );
+};


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 위키 생성 및 인증 질문 변경 시 옵션으로 이메일로 질문과 답변을 보내주는 기능 구현

## 📝 작업 내용 설명
- email.js 라이브러리를 사용하여 사용자가 별도로 입력한 이메일로 질문과 답변을 보내줍니다.
- 이메일을 별도로 입력하지 않으면 이메일은 전송되지 않습니다.

## 📷 스크린샷
<img width="539" alt="스크린샷 2024-09-10 오후 7 52 30" src="https://github.com/user-attachments/assets/61db7f7e-9667-490a-a776-788eae64f670">
<img width="350" alt="스크린샷 2024-09-10 오후 7 21 28" src="https://github.com/user-attachments/assets/f5db753f-e5e5-4b8d-9372-44136c5b6687">
<img width="350" alt="스크린샷 2024-09-10 오후 7 51 56" src="https://github.com/user-attachments/assets/0cc666e2-4064-41f2-8aed-6d62a4d9cc16">

## 💬 리뷰 요구사항(선택)
> 수정할 부분이나 버그가 있다면 알려주세요!

## 🏷️ 연관된 이슈 번호
> #35 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x ] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
