### PR TITLE
Refactor -  유효성 검사 커스텀훅 최적화 작업

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     "prettier/prettier": "error",
     "no-console": "warn",
     "no-unused-vars": "off",
+    // "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": "warn",
     "import/no-unresolved": "off",
     "react/react-in-jsx-scope": "off",

--- a/components/@shared/Input/ValidInput.tsx
+++ b/components/@shared/Input/ValidInput.tsx
@@ -1,13 +1,13 @@
 import classNames from 'classnames';
 import styles from './ValidInput.module.scss';
-import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
+import { FieldError, FieldErrorsImpl, Merge, UseFormRegisterReturn } from 'react-hook-form';
 import { HTMLInputTypeAttribute } from 'react';
 
 interface ValidInputProps {
   label?: string;
   htmlFor?: string;
-  error: FieldError | undefined;
-  message: string | undefined;
+  error: FieldError | Merge<FieldError, FieldErrorsImpl> | undefined;
+  message: string | FieldError | Merge<FieldError, FieldErrorsImpl> | undefined;
   register: UseFormRegisterReturn;
   type?: HTMLInputTypeAttribute;
   placeholder?: string;
@@ -36,7 +36,7 @@ export default function ValidInput({
         placeholder={placeholder}
         {...register}
       />
-      {message && <p className={classNames('text-xs', styles.message)}>{message}</p>}
+      {message && <p className={classNames('text-xs', styles.message)}>{message.toString()}</p>}
     </div>
   );
 }

--- a/components/myPage/CreateWikiForm.tsx
+++ b/components/myPage/CreateWikiForm.tsx
@@ -1,32 +1,54 @@
-import { FormInputValues, useValidForm } from '@/hooks/useValidForm';
+import { useValidForm, ValidationConfig } from '@/hooks/useValidForm';
 import styles from './MyPageForm.module.scss';
 import classNames from 'classnames';
-import { SubmitHandler } from 'react-hook-form';
+import { FieldValues, SubmitHandler } from 'react-hook-form';
 import ValidInput from '../@shared/Input/ValidInput';
 import { createProfile } from '@/apis/auth/createProfile';
 import { useSnackBar } from '@/contexts/SnackbarProvider';
 import { useAuth } from '@/contexts/AuthProvider';
 import { sendMail } from '@/utils/sendMail';
-import SendEmailInput from './SendEmailInput';
+import { VALID_OPTIONS } from '@/constants/validOptions';
+
+const createWikiFormConfig: ValidationConfig = {
+  securityAnswer: {
+    required: '질문을 입력해주세요',
+    minLength: VALID_OPTIONS.minLength2,
+    maxLength: VALID_OPTIONS.maxLength10,
+  },
+  securityQuestion: {
+    required: '답변을 입력해주세요',
+    minLength: VALID_OPTIONS.minLength2,
+    maxLength: VALID_OPTIONS.maxLength10,
+  },
+  toEmail: {
+    required: false,
+    pattern: VALID_OPTIONS.emailPattern,
+  },
+};
 
 export default function CreateWikiForm() {
   const { syncUserAuthState, user } = useAuth();
   const { openSnackBar } = useSnackBar();
-  const { register, errors, handleSubmit } = useValidForm(['securityAnswer', 'securityQuestion']);
+  const { register, errors, handleSubmit, setValue } = useValidForm({ validationConfig: createWikiFormConfig });
 
-  const handleFormSubmit: SubmitHandler<FormInputValues> = async (formData, event) => {
-    if (formData.securityAnswer && formData.securityQuestion && event && user) {
+  const handleFormSubmit: SubmitHandler<FieldValues> = async formData => {
+    if (formData.securityAnswer && formData.securityQuestion && user) {
       const { securityAnswer, securityQuestion } = formData;
       const response = await createProfile({ securityAnswer, securityQuestion });
 
       if (response) {
         openSnackBar({ type: 'success', content: '위키 생성이 완료되었습니다.' });
-        const toEmailInput = event.target['toEmail'];
-        if (toEmailInput.value) {
-          sendMail({ answer: securityAnswer, question: securityQuestion, name: user.name, email: toEmailInput.value });
-          // submit 시에만 필요한 input이기 때문에 불필요한 리렌더링 제거를 위해 따로 onChange 함수로 value를 관리하지 않기 때문
-          toEmailInput.value = '';
+        if (formData.toEmail) {
+          sendMail({
+            answer: securityAnswer,
+            question: securityQuestion,
+            name: user.name,
+            email: formData.toEmail,
+          });
+          setValue('toEmail', '');
         }
+        setValue('securityAnswer', '');
+        setValue('securityQuestion', '');
         syncUserAuthState();
       } else {
         openSnackBar({ type: 'error', content: '위키 생성에 실패하였습니다.' });
@@ -50,7 +72,14 @@ export default function CreateWikiForm() {
         register={register.securityAnswer}
         placeholder={'답변을 입력해주세요'}
       />
-      <SendEmailInput />
+      <ValidInput
+        type="email"
+        label={'이메일을 입력하면 인증 퀴즈 내용을 보내드려요'}
+        placeholder={'비워두면 이메일은 가지 않아요..'}
+        error={errors.toEmail}
+        message={errors.toEmail?.message}
+        register={register.toEmail}
+      />
 
       <div className={styles.buttonWrapper}>
         <button className={'button'}>생성하기</button>

--- a/components/myPage/SendEmailInput.tsx
+++ b/components/myPage/SendEmailInput.tsx
@@ -1,8 +1,0 @@
-export default function SendEmailInput() {
-  return (
-    <>
-      <label className={'text-md'}>질문과 답변을 받을 이메일</label>
-      <input className={'input'} type="email" name={'toEmail'} placeholder={'비워두면 이메일은 가지 않아요..'} />
-    </>
-  );
-}

--- a/components/myPage/UpdatePasswordForm.tsx
+++ b/components/myPage/UpdatePasswordForm.tsx
@@ -1,19 +1,38 @@
-import { FormInputValues, useValidForm } from '@/hooks/useValidForm';
-import { SubmitHandler } from 'react-hook-form';
+import { useValidForm, ValidationConfig } from '@/hooks/useValidForm';
+import { FieldValues, SubmitHandler } from 'react-hook-form';
 import ValidInput from '../@shared/Input/ValidInput';
 import { useRouter } from 'next/router';
 import { updatePassword } from '@/apis/auth/updatePassword';
 import { useSnackBar } from '@/contexts/SnackbarProvider';
 import styles from './MyPageForm.module.scss';
 import classNames from 'classnames';
+import { VALID_OPTIONS } from '@/constants/validOptions';
+
+const updatePasswordFormConfig: ValidationConfig = {
+  currentPassword: {
+    required: '현재 비밀번호를 입력해주세요',
+    pattern: VALID_OPTIONS.passwordPattern,
+  },
+  password: {
+    required: '새로운 비밀번호를 입력해주세요',
+    pattern: VALID_OPTIONS.passwordPattern,
+  },
+  passwordConfirmation: {
+    required: '비밀번호를 한 번 더 입력해주세요',
+    pattern: VALID_OPTIONS.passwordPattern,
+    validate: {
+      matched: (value, formValues) => value === formValues.password || '비밀번호가 일치하지 않습니다.',
+    },
+  },
+};
 
 export default function UpdatePasswordForm() {
   const { openSnackBar } = useSnackBar();
   const router = useRouter();
 
-  const { register, errors, handleSubmit } = useValidForm(['currentPassword', 'password', 'passwordConfirmation']);
+  const { register, errors, handleSubmit } = useValidForm({ validationConfig: updatePasswordFormConfig });
 
-  const handleFormSubmit: SubmitHandler<FormInputValues> = async formData => {
+  const handleFormSubmit: SubmitHandler<FieldValues> = async formData => {
     if (formData.currentPassword && formData.password && formData.passwordConfirmation) {
       const { currentPassword, password, passwordConfirmation } = formData;
       const response = await updatePassword({ currentPassword, password, passwordConfirmation });

--- a/constants/validOptions.ts
+++ b/constants/validOptions.ts
@@ -1,0 +1,12 @@
+export const VALID_OPTIONS = {
+  passwordPattern: {
+    value: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/,
+    message: '영문, 숫자를 포함하여 8자 이상으로 작성해주세요',
+  },
+  emailPattern: {
+    value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+    message: '이메일 형식으로 작성해주세요',
+  },
+  minLength2: { value: 2, message: '2자 이상으로 작성해주세요.' },
+  maxLength10: { value: 10, message: '10자 이내로 작성해주세요.' },
+};

--- a/hooks/useValidForm.ts
+++ b/hooks/useValidForm.ts
@@ -1,109 +1,52 @@
-import { useForm, UseFormRegisterReturn } from 'react-hook-form';
+import { Mode, RegisterOptions, useForm, UseFormRegisterReturn } from 'react-hook-form';
 
-export interface FormInputValues {
-  name?: string;
-  email?: string;
-  password?: string;
-  passwordConfirmation?: string;
-  currentPassword?: string;
-  currentSecurityAnswer?: string;
-  securityQuestion?: string;
-  securityAnswer?: string;
-}
+export type ValidationConfig = Record<string, RegisterOptions>;
 
-type FormField = keyof FormInputValues;
-
-// argument로 들어온 배열에 속하는 요소만 유효성 검사 로직에 등록됩니다.
-export const useValidForm = (fieldList: FormField[]) => {
+export const useValidForm = ({
+  validationConfig,
+  mode = 'onChange',
+}: {
+  validationConfig: ValidationConfig;
+  mode?: Mode;
+}) => {
   const {
     register,
     trigger,
     handleSubmit,
     setValue,
     formState: { errors },
-  } = useForm<FormInputValues>({ mode: 'onChange' });
+  } = useForm({ mode });
 
-  // field값을 받아서 해당 field값 맞는 register를 생성하는 함수
-  const getRegisterOption = (field: FormField) => {
-    switch (field) {
-      case 'name':
-        return register('name', {
-          required: true,
-          minLength: { value: 2, message: '2자 이상으로 작성해주세요.' },
-          maxLength: { value: 10, message: '10자 이내로 작성해주세요.' },
-        });
-      case 'email':
-        return register('email', {
-          required: true,
-          pattern: {
-            value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-            message: '이메일 형식으로 작성해주세요',
-          },
-        });
-      case 'password':
-        return register('password', {
-          required: true,
-          pattern: {
-            value: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/,
-            message: '영문, 숫자를 포함하여 8자 이상으로 작성해주세요',
-          },
-          onChange: () => trigger('passwordConfirmation'), //password를 입력할 때마다 passwordConfirmation의 유효성 검사도 함께 트리거 되도록 함
-        });
-      case 'currentPassword':
-        return register('currentPassword', {
-          required: true,
-          pattern: {
-            value: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/,
-            message: '영문, 숫자를 포함하여 8자 이상으로 작성해주세요',
-          },
-        });
-      case 'passwordConfirmation':
-        return register('passwordConfirmation', {
-          required: true,
-          pattern: {
-            value: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/,
-            message: '영문, 숫자를 포함하여 8자 이상으로 작성해주세요',
-          },
-          validate: {
-            matched: (value, formValues) => value === formValues.password || '비밀번호가 일치하지 않습니다.',
-          },
-        });
-      case 'currentSecurityAnswer':
-      case 'securityQuestion':
-      case 'securityAnswer':
-        return register(field, {
-          required: true,
-          minLength: { value: 2, message: '2자 이상으로 작성해주세요.' },
-          maxLength: { value: 20, message: '20자 이내로 작성해주세요.' },
-          onChange: event => {
-            const { value } = event.target;
-            // 첫 문자로 공백이 오는 것을 방지
-            return setValue(field, value === ' ' ? value.trim() : value);
-          },
-        });
-      default: // 지정된 케이스가 없다면 undefined를 반환하여 커스텀 훅의 register 반환값에 추가되지 않도록 함
-        return undefined;
-    }
+  // 받은 config에 맞게 register를 생성하는 함수
+  const getRegisterOption = (fieldName: string, validationRule: RegisterOptions) => {
+    return register(fieldName, {
+      ...validationRule,
+      onChange: event => {
+        const { value } = event.target;
+        if (fieldName === 'password' && Object.hasOwn(validationConfig, 'passwordConfirmation')) {
+          // 비밀번호의 경우, 비밀번호 확인이 인자로 받은 formConfig에 존재한다면
+          // 비밀번호 입력에 따라 비밀번호 확인 유효성 검사도 함께 작동하도록 구현
+          trigger('passwordConfirmation');
+        }
+        // 첫 문자로 공백이 오는 것을 방지
+        setValue(fieldName, value === ' ' ? value.trim() : value);
+      },
+    });
   };
 
   // 선택된 필드들만 register로 등록되고, 반환 객체에 추가
-  const selectedRegisters = fieldList.reduce(
-    (acc, fieldName) => {
-      const registerOption = getRegisterOption(fieldName);
-
-      if (registerOption) {
-        // registerOption이 반환값이 있을 경우에만 반환 객체에 추가
-        acc[fieldName] = registerOption;
-      }
+  const createdRegisterObject = Object.entries(validationConfig).reduce(
+    (acc, [fieldName, validationRule]) => {
+      acc[fieldName] = getRegisterOption(fieldName, validationRule);
 
       return acc;
     },
-    {} as Record<FormField, UseFormRegisterReturn>,
+    {} as Record<string, UseFormRegisterReturn>,
   );
 
   return {
     handleSubmit,
-    register: selectedRegisters,
+    register: createdRegisterObject,
     errors,
     setValue,
   };

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,16 +1,28 @@
 import Link from 'next/link';
-import { SubmitHandler } from 'react-hook-form';
 import React from 'react';
-import { FormInputValues, useValidForm } from '@/hooks/useValidForm';
+import { useValidForm, ValidationConfig } from '@/hooks/useValidForm';
 import ValidInput from '@/components/@shared/Input/ValidInput';
 import { useAuth } from '@/contexts/AuthProvider';
+import { FieldValues } from 'react-hook-form';
+import { VALID_OPTIONS } from '@/constants/validOptions';
+
+const loginValidationConfig: ValidationConfig = {
+  email: {
+    required: 'e-mail을 입력해주세요',
+    pattern: VALID_OPTIONS.emailPattern,
+  },
+  password: {
+    required: '비밀번호를 입력해주세요',
+    pattern: VALID_OPTIONS.passwordPattern,
+  },
+};
 
 export default function LogInPage() {
   const { logIn } = useAuth();
 
-  const { register, errors, handleSubmit } = useValidForm(['email', 'password']);
+  const { register, errors, handleSubmit } = useValidForm({ validationConfig: loginValidationConfig });
 
-  const handleFormSubmit: SubmitHandler<FormInputValues> = async formData => {
+  const handleFormSubmit = async (formData: FieldValues) => {
     if (formData.email && formData.password) {
       const { email, password } = formData;
       await logIn({ email, password });

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,18 +1,42 @@
 import Link from 'next/link';
-import { SubmitHandler } from 'react-hook-form';
+import { FieldValues, SubmitHandler } from 'react-hook-form';
 import React from 'react';
-import { FormInputValues, useValidForm } from '@/hooks/useValidForm';
 import ValidInput from '@/components/@shared/Input/ValidInput';
 import { useAuth } from '@/contexts/AuthProvider';
 import { useRouter } from 'next/router';
+import { useValidForm, ValidationConfig } from '@/hooks/useValidForm';
+import { VALID_OPTIONS } from '@/constants/validOptions';
+
+const signUpValidationConfig: ValidationConfig = {
+  name: {
+    required: '이름을 입력해주세요',
+    minLength: VALID_OPTIONS.minLength2,
+    maxLength: VALID_OPTIONS.maxLength10,
+  },
+  email: {
+    required: 'e-mail을 입력해주세요',
+    pattern: VALID_OPTIONS.emailPattern,
+  },
+  password: {
+    required: '비밀번호를 입력해주세요',
+    pattern: VALID_OPTIONS.passwordPattern,
+  },
+  passwordConfirmation: {
+    required: '비밀번호를 한 번 더 입력해주세요',
+    pattern: VALID_OPTIONS.passwordPattern,
+    validate: {
+      matched: (value, formValues) => value === formValues.password || '비밀번호가 일치하지 않습니다.',
+    },
+  },
+};
 
 export default function SignUpPage() {
   const { signUp } = useAuth();
   const router = useRouter();
 
-  const { register, errors, handleSubmit } = useValidForm(['email', 'name', 'password', 'passwordConfirmation']);
+  const { register, errors, handleSubmit } = useValidForm({ validationConfig: signUpValidationConfig });
 
-  const handleFormSubmit: SubmitHandler<FormInputValues> = async formData => {
+  const handleFormSubmit: SubmitHandler<FieldValues> = async formData => {
     if (formData.email && formData.name && formData.password && formData.passwordConfirmation) {
       const { email, name, password, passwordConfirmation } = formData;
       await signUp({ email, name, password, passwordConfirmation });


### PR DESCRIPTION
## ✏️ 작업 내용 요약
- useValidForm 훅의 유효성 검사 로직을 외부에서 주입할 수 있도록 변경하였습니다.
이를 통해 사용자가 원하는 조건으로 유효성 검사를 수행하고 필요한 input을 추가할 수 있게 되었습니다.

## 📝 작업 내용 설명
- 기존 useValidForm() 훅은 내부에 switch 문으로 input 이름과 유효성 검사 로직을 미리 정의해 두었습니다.
- 이 방식은 기존 로직을 그대로 사용할 때는 편리했지만, 새로운 조건이 필요하거나 약간의 변경이 필요할 때마다 훅 내부를 수정해야 하는 번거로움이 있었습니다.
- 이 문제를 해결하기 위해, useValidForm 훅 호출 시,
사용할 input name과 유효성 검사 로직이 담긴 ValidConfig를 작성하여 인자로 전달하도록 변경하였습니다.
- 자주 사용되는 검사 패턴(비밀번호, 이메일, 최대-최소 길이 등)은 상수로 만들어 별도로 저장해 두어 코드 재사용성을 높였습니다.
- 사용자가 Config를 직접 작성하므로 어떤 유효성 검사가 이루어지는지 즉시 파악할 수 있고,
원하는 검사 로직과 새로운 input을 자유롭게 추가할 수 있도록 하여 더욱 직관적이고 유연한 유효성 검사 커스텀 훅으로 리팩토링하였습니다.
- 인자로는 mode 프로퍼티도 선택적으로 받을 수 있는데, 이는 유효성 검사 로직의 시행이 입력 당시, 제출 당시 등으로 지정이 가능하게 합니다.
- 이 리팩토링한 useValidForm 훅은 여전히 기존 ValidInput 컴포넌트와 연계하여 유효성 검사 input과 form을 쉽게 만들 수 있습니다.

## 📷 스크린샷 
<img width="553" alt="image" src="https://github.com/user-attachments/assets/40238826-1ea8-46e1-8bd1-31ea98ba2663">
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/9c1363b3-ab90-4e2a-9f9a-d5bda707cbe2">
<img width="979" alt="image" src="https://github.com/user-attachments/assets/edf33f13-3475-4f24-ba72-8a41f94eae33">

## 💬 리뷰 요구사항
> 수정할 부분이나 버그가 발견된다면 언제든 알려주시기 바랍니다.

## 🏷️ 연관된 이슈 번호
> #3

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.