### PR TITLE
Fix - Polling 주기 60초에서 3초로 변경

### DIFF
--- a/components/@shared/header/Alarm.tsx
+++ b/components/@shared/header/Alarm.tsx
@@ -35,16 +35,16 @@ export default function Alarm() {
   };
 
   useEffect(() => {
-    // 기본 delay값 60초
-    let delay = 60000;
+    // 기본 delay값 3초
+    let delay = 3000;
     let timer: NodeJS.Timeout;
 
     // 남은 Notification 유무 확인을 위한 함수
     const fetchNotification = async () => {
       const responseNotificationList = await getNotifications();
       if (!responseNotificationList) {
-        // 요청 실패가 서버 부하 문제일 수 있으므로 딜레이 1.2배 증가
-        delay *= 1.2;
+        // 요청 실패가 서버 부하 문제일 수 있으므로 딜레이 2배 증가
+        delay *= 2;
       } else {
         setNotificationList(responseNotificationList);
         if (responseNotificationList.length > 0) {


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> Polling 주기 60초에서 3초로 변경

## 📝 작업 내용 설명
- 주강사님께 Polling 주기에 대해 여쭤본 결과, 우리 프로젝트 규모 상 3초여도 괜찮으시다고 하셔서
Polling 주기를 60초에서 3초로 변경였습니다.

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 이로 인해 버그가 발생한다면 알려주세요!

## 🏷️ 연관된 이슈 번호
> #33 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
