### PR TITLE
Hotfix - 윈도우 운영체제에서 좌우스크롤 제거 및 마이페이지 위키 생성, 변경 폼 타이틀 추가

### DIFF
--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -11,9 +11,15 @@ export default function MyPage() {
       <h3 className={'text-2xl'}>계정 설정</h3>
       <UpdatePasswordForm />
       {user?.profile ? (
-        <UpdateSecurityQuizForm code={user.profile.code} currentSecurityQuestion={user.profile.securityQuestion} />
+        <>
+          <h3 className={'text-2xl'}>위키 생성 퀴즈 관리</h3>
+          <UpdateSecurityQuizForm code={user.profile.code} currentSecurityQuestion={user.profile.securityQuestion} />
+        </>
       ) : (
-        <CreateWikiForm />
+        <>
+          <h3 className={'text-2xl'}>프로필 생성</h3>
+          <CreateWikiForm />
+        </>
       )}
     </main>
   );

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -10,6 +10,7 @@ body {
   padding-bottom: $footer-height;
   min-height: 100vh;
   max-width: 100vw;
+  overflow-x: hidden;
 }
 
 .button {


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 윈도우 운영체제에서 좌우스크롤 제거 및 마이페이지 위키 생성, 변경 폼 타이틀 추가

## 📝 작업 내용 설명
- 윈도우 운영 체제에서 좌우 스크롤이 나오는 이슈 해결
- 마이페이지 위키 생성, 변경 폼 타이틀 추가

## 📷 스크린샷
<img src="https://github.com/user-attachments/assets/e6234305-303d-4689-9f80-6f84050a0100" width="400" >
<img src="https://github.com/user-attachments/assets/d4b49a6b-ba69-488c-88e1-d5e83cbb718b" width="400" >


## 💬 리뷰 요구사항
> 또 다른 버그나 이슈 사항이 있으면 알려주세요!

## 🏷️ 연관된 이슈 번호
>  #54

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
