### PR TITLE
#54 fix: 실제 모바일 환경을 고려한 이미지 비율 조정

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,13 +4,19 @@ import Providers from '@/contexts/Providers';
 import '@/styles/globals.scss';
 import '@/styles/quillCustom.scss';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <Providers>
-      <Header />
-      <Component {...pageProps} />
-      <Footer />
-    </Providers>
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      </Head>
+      <Providers>
+        <Header />
+        <Component {...pageProps} />
+        <Footer />
+      </Providers>
+    </>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,9 +3,7 @@ import { Html, Head, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html lang="en">
-      <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />

--- a/pages/landing/Landing.module.scss
+++ b/pages/landing/Landing.module.scss
@@ -49,8 +49,8 @@
 .LandingContainer {
   background-color: #ecf0fa;
   img {
-    height: 100%; /* 이미지 높이를 부모 컨테이너의 100%로 설정 */
-    width: auto; /* 비율 유지 */
+    height: 100%;
+    width: 100%;
   }
 }
 
@@ -105,6 +105,8 @@
     min-width: 336px;
 
     img {
+      height: 100%; /* 이미지 높이를 부모 컨테이너의 100%로 설정 */
+      width: auto; /* 비율 유지 */
       position: relative;
       top: 0px;
       left: 50%;


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 실제 모바일 환경을 고려한 이미지 비율 조정

## 📝 작업 내용 설명
- 메타 태그를 _document.tsx 에서 _app.tsx로 이동(Next 공식 문서에서 권고)
- 랜딩 페이지 이미지 비율 조정

## 🏷️ 연관된 이슈 번호
> #54 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
