### PR TITLE
#54 fix: Pretandard 폰트 적용 가변 프리셋 적용

### DIFF
--- a/components/@shared/modal/Modal.module.scss
+++ b/components/@shared/modal/Modal.module.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   padding: 40px 0;
   span {
-    font-family: Pretendard !important;
+    font-family: 'Pretendard Variable' !important;
     font-size: 14px;
     line-height: 22.4px;
     color: $gray400;
@@ -60,12 +60,12 @@
 }
 
 .errorMessage {
-  font-family: Pretendard !important;
+  font-family: 'Pretendard Variable' !important;
   color: $secondary-red200;
 }
 
 .footerMessage {
-  font-family: Pretendard !important;
+  font-family: 'Pretendard Variable' !important;
   line-height: 14.32px;
   font-weight: 400;
   font-size: 12px;
@@ -75,7 +75,7 @@
 .message {
   padding-top: 30px;
   margin-bottom: 5px;
-  font-family: Pretendard !important;
+  font-family: 'Pretendard Variable' !important;
   font-size: 16px;
   font-weight: 600;
   line-height: 26px;
@@ -84,7 +84,7 @@
 
 .subMessage {
   padding-bottom: 10px;
-  font-family: Pretendard !important;
+  font-family: 'Pretendard Variable' !important;
   font-size: 14px;
   font-weight: 400;
   line-height: 26px;

--- a/styles/_font.scss
+++ b/styles/_font.scss
@@ -23,12 +23,19 @@
 
 html {
   font-family:
+    'Pretendard Variable',
     Pretendard,
-    맑은 고딕,
-    malgun gothic,
-    AppleGothicNeoSD,
-    Apple SD 산돌고딕 Neo,
-    Microsoft NeoGothic,
-    Droid sans,
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    'Helvetica Neue',
+    'Segoe UI',
+    'Apple SD Gothic Neo',
+    'Noto Sans KR',
+    'Malgun Gothic',
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
     sans-serif;
 }

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -13,7 +13,7 @@
 }
 
 //text style
-@mixin fontStyle300($font-family: Pretendard, $font-size: 12px, $line-height: 115%, $color: $gray500) {
+@mixin fontStyle300($font-family: 'Pretendard Variable', $font-size: 12px, $line-height: 115%, $color: $gray500) {
   font-family: $font-family;
   font-size: $font-size;
   font-weight: 300;
@@ -21,7 +21,7 @@
   color: $color;
 }
 
-@mixin fontStyle400($font-family: Pretendard, $font-size: 18px, $line-height: 115%, $color: $gray500) {
+@mixin fontStyle400($font-family: 'Pretendard Variable', $font-size: 18px, $line-height: 115%, $color: $gray500) {
   font-family: $font-family;
   font-size: $font-size;
   font-weight: 400;
@@ -29,7 +29,7 @@
   color: $color;
 }
 
-@mixin fontStyle500($font-family: Pretendard, $font-size: 20px, $line-height: 115%, $color: $gray400) {
+@mixin fontStyle500($font-family: 'Pretendard Variable', $font-size: 20px, $line-height: 115%, $color: $gray400) {
   font-family: $font-family;
   font-size: $font-size;
   font-weight: 400;
@@ -37,7 +37,7 @@
   color: $color;
 }
 
-@mixin fontStyle600($font-family: Pretendard, $font-size: 20px, $line-height: 115%, $color: $gray500) {
+@mixin fontStyle600($font-family: 'Pretendard Variable', $font-size: 20px, $line-height: 115%, $color: $gray500) {
   font-family: $font-family;
   font-size: $font-size;
   font-weight: 600;
@@ -45,7 +45,7 @@
   color: $color;
 }
 
-@mixin fontStyle700($font-family: Pretendard, $font-size: 24px, $line-height: 115%, $color: $gray500) {
+@mixin fontStyle700($font-family: 'Pretendard Variable', $font-size: 24px, $line-height: 115%, $color: $gray500) {
   font-family: $font-family;
   font-size: $font-size;
   font-weight: 700;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -90,7 +90,7 @@ body {
     height: 50px !important;
     padding: 13px 20px 15px 20px !important;
     border-radius: 10px !important;
-    font-family: Pretendard !important;
+    font-family: 'Pretendard Variable' !important;
     font-size: 14px !important;
     font-weight: 600 !important;
     gap: 20px !important;

--- a/styles/quillCustom.scss
+++ b/styles/quillCustom.scss
@@ -4,13 +4,20 @@
 
 .quill.custom .ql-container {
   font-family:
+    'Pretendard Variable',
     Pretendard,
-    맑은 고딕,
-    malgun gothic,
-    AppleGothicNeoSD,
-    Apple SD 산돌고딕 Neo,
-    Microsoft NeoGothic,
-    Droid sans,
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    'Helvetica Neue',
+    'Segoe UI',
+    'Apple SD Gothic Neo',
+    'Noto Sans KR',
+    'Malgun Gothic',
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
     sans-serif;
 }
 


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> Pretandard 폰트 적용 가변 프리셋 적용

## 📝 작업 내용 설명
> 어떤 기종에서든 같은 글꼴이 적용될 수 있도록 font-family 수정

## 🏷️ 연관된 이슈 번호
> #54 
## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
