### PR TITLE
#54 fix: pretandard 웹폰트를 css에서 link로 변경

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,13 @@ import { Html, Head, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link
+          rel="stylesheet"
+          as="style"
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/styles/_font.scss
+++ b/styles/_font.scss
@@ -1,5 +1,3 @@
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css');
-
 @font-face {
   font-family: 'HakgyoansimDunggeunmisoTTF-B';
   src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/2408-5@1.0/HakgyoansimDunggeunmisoTTF-B.woff2') format('woff2');

--- a/styles/quillCustom.scss
+++ b/styles/quillCustom.scss
@@ -1,6 +1,5 @@
 @import '@/styles/_variables';
 @import '@/styles/_mixins';
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css');
 
 .quill.custom .ql-container {
   font-family:


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> pretandard 웹폰트를 css에서 link로 변경

## 🏷️ 연관된 이슈 번호
> #54 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
