### PR TITLE
Fix- 회원가입, 로그인 실패 메세지 수정

### DIFF
--- a/apis/auth/authenticateLogin.ts
+++ b/apis/auth/authenticateLogin.ts
@@ -30,12 +30,11 @@ export const authenticateLogIn = async ({
     body: JSON.stringify({ email, password }),
   });
 
-  if (!response.ok) {
-    const errorMessage = await response.json();
-    throw new Error(errorMessage.message || '예기치 않은 오류가 발생했습니다.');
-  }
-
   const result = await response.json();
+
+  if (!response.ok) {
+    throw new Error(result.message || '예기치 않은 오류가 발생했습니다.');
+  }
 
   return result;
 };

--- a/apis/auth/authenticateLogin.ts
+++ b/apis/auth/authenticateLogin.ts
@@ -31,7 +31,8 @@ export const authenticateLogIn = async ({
   });
 
   if (!response.ok) {
-    return undefined;
+    const errorMessage = await response.json();
+    throw new Error(errorMessage.message || '예기치 않은 오류가 발생했습니다.');
   }
 
   const result = await response.json();

--- a/apis/auth/authenticateSignUp.ts
+++ b/apis/auth/authenticateSignUp.ts
@@ -31,12 +31,11 @@ export const authenticateSignUp = async ({
     body: JSON.stringify({ email, name, password, passwordConfirmation }),
   });
 
-  if (!response.ok) {
-    const errorMessage = await response.json();
-    throw new Error(errorMessage.message || '예기치 않은 오류가 발생했습니다.');
-  }
-
   const result = await response.json();
+
+  if (!response.ok) {
+    throw new Error(result.message || '예기치 않은 오류가 발생했습니다.');
+  }
 
   return result;
 };

--- a/apis/auth/authenticateSignUp.ts
+++ b/apis/auth/authenticateSignUp.ts
@@ -32,7 +32,8 @@ export const authenticateSignUp = async ({
   });
 
   if (!response.ok) {
-    return undefined;
+    const errorMessage = await response.json();
+    throw new Error(errorMessage.message || '예기치 않은 오류가 발생했습니다.');
   }
 
   const result = await response.json();

--- a/contexts/SnackbarProvider.tsx
+++ b/contexts/SnackbarProvider.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactNode, useContext } from 'react';
+import { useState } from 'react';
+import { act, createContext, ReactNode, useContext } from 'react';
 import { message, Space } from 'antd';
 import iconSuccess from '@/public/icon/icon-success.png';
 import iconError from '@/public/icon/icon-error.png';
@@ -18,7 +19,7 @@ interface SnackBarContextValue {
 const SnackbarContext = createContext<SnackBarContextValue | undefined>(undefined);
 
 export default function SnackBarProvider({ children }: { children: ReactNode }) {
-  const [messageApi, contextHolder] = message.useMessage({ top: 120 });
+  const [messageApi, contextHolder] = message.useMessage({ top: 120, maxCount: 3 });
 
   const iconSrc: Record<SnackBarType, ReactNode> = {
     success: <Image src={iconSuccess} alt={'성공 메시지 아이콘'} height={20} width={20} />,

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -39,8 +39,10 @@ export default function SignUpPage() {
   const handleFormSubmit: SubmitHandler<FieldValues> = async formData => {
     if (formData.email && formData.name && formData.password && formData.passwordConfirmation) {
       const { email, name, password, passwordConfirmation } = formData;
-      await signUp({ email, name, password, passwordConfirmation });
-      router.push('/home');
+      const sucessSignUp = await signUp({ email, name, password, passwordConfirmation });
+      if (sucessSignUp) {
+        router.push('/home');
+      }
     }
   };
 


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 회원가입, 로그인 실패 시 메세지를 서버에서 받아오도록 수정

## 📝 작업 내용 설명
- 회원가입 실패시 에도 home으로 가지는 문제가 있어서 AuthProvide의 signUp에서 boolean값을 반환하도록 수정 했습니다.
- authenticateLogin, authenticateSignUp api에서 undefined대신 response.json에서 에러메세지를 가져오도록 수정했습니다.
- 스낵바가 무한으로 출력되서 화면 밖에 까지 생성되는 문제가 있어 갯수를 3개로 제한했습니다

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 🏷️ 연관된 이슈 번호
> #70

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
