### PR TITLE
Fix - 프로필 디테일 디자인 변경, 프로필 카드 수정

### DIFF
--- a/components/wiki/ProfileDetail.module.scss
+++ b/components/wiki/ProfileDetail.module.scss
@@ -11,7 +11,7 @@
 }
 
 .pcIntroduce {
-  @include fontStyle400;
+  @include fontStyle600($font-size: 18px);
   @include ellipsis;
   text-align: center;
   padding: 20px 20px;
@@ -52,6 +52,12 @@
   p {
     @include fontStyle400($font-size: 14px, $line-height: 24px, $color: $gray400);
   }
+}
+
+.instagram {
+  height: 24px;
+  display: flex;
+  align-items: center;
 }
 
 .profileValue {
@@ -120,7 +126,7 @@
 
   .introduce {
     display: block;
-    @include fontStyle400;
+    @include fontStyle600($font-size: 18px);
     @include ellipsis;
     text-align: center;
     padding: 20px 20px 0;

--- a/components/wiki/ProfileDetails.tsx
+++ b/components/wiki/ProfileDetails.tsx
@@ -41,8 +41,13 @@ export default function ProfileDetails({ profile }: ProfileDetailProps) {
             <p>{profile.mbti}</p>
             <p>{profile.job}</p>
             {profile.sns ? (
-              <a href={`${INSTAGRAM_URL}${profile.sns}`} target="_blank" rel="noopener noreferrer">
-                <Image src="/icon/icon-instagram.png" alt="sns 아이콘" width={24} height={24} />
+              <a
+                href={`${INSTAGRAM_URL}${profile.sns}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.instagram}
+              >
+                <Image src="/icon/icon-instagram.png" alt="sns 아이콘" width={18} height={18} />
               </a>
             ) : (
               <p></p>

--- a/components/wikiList/WikiCard.tsx
+++ b/components/wikiList/WikiCard.tsx
@@ -46,7 +46,9 @@ export default function WikiCard({ profileCard }: WikiCardProps) {
       <section className={styles.detail}>
         <h1>{profileCard.name}</h1>
         <p>
-          {profileCard.city}, {profileCard.nationality}
+          {profileCard.city && profileCard.nationality
+            ? `${profileCard.city}, ${profileCard.nationality}`
+            : profileCard.city || profileCard.nationality}
         </p>
         <p>{profileCard.job}</p>
       </section>


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 프로필 디테일 디자인 변경, 프로필 카드 수정

## 📝 작업 내용 설명
- 한 줄 소개 font-size를 굵게 변경했습니다.
- 인스타그램 아이콘 사이즈를 변경했습니다.
- 프로필 카드에 도시, 국적이 공백일 때 쉼표를 제거했습니다.


## 🏷️ 연관된 이슈 번호
> #69 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
