### PR TITLE
#21 fix: 랜딩 페이지 첫 이미지 크기 상향 조정

### DIFF
--- a/pages/landing/Landing.module.scss
+++ b/pages/landing/Landing.module.scss
@@ -67,15 +67,15 @@
   background-image: url('../../public/landing/landing-ellipse.png');
   background-repeat: no-repeat;
   background-size: 100% 100%;
-  background-position: 0 300px;
+  background-position: 0 215px;
 
   @include mobile {
-    background-position: 0 200px;
+    background-position: 0 125px;
   }
 }
 
 .introSection {
-  padding-top: 120px;
+  padding-top: 80px;
   text-align: center;
 
   @include mobile {
@@ -123,7 +123,7 @@
     align-items: center;
     padding-top: 54px;
     position: relative;
-    height: 685.67px;
+    height: 1000px;
 
     @include mobile {
       height: 275px;
@@ -132,10 +132,14 @@
     img {
       padding: 0 20px;
       position: absolute;
-      top: -20px;
+      top: -60px;
       height: auto;
-      max-width: 685.67px;
-      aspect-ratio: 884 / 685.67;
+      max-width: 1000px;
+      aspect-ratio: 1832 / 1421;
+
+      @include tablet {
+        top: -30px;
+      }
 
       @include mobile {
         max-width: 450px;

--- a/pages/landing/index.tsx
+++ b/pages/landing/index.tsx
@@ -41,7 +41,7 @@ export default function Landing() {
           </Fade>
           <div className={styles.background}>
             <Bounce className={styles.introImageWrapper} delay={1900} triggerOnce>
-              <Image src={profileImg} alt={'프로필 소개 이미지'} height={685.67} width={884} />
+              <Image src={profileImg} alt={'프로필 소개 이미지'} height={1421} width={1832} />
             </Bounce>
           </div>
         </section>


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 랜딩 페이지 첫 이미지 크기 상향 조정

## 📝 작업 내용 설명
- 랜딩 페이지 첫 이미지 크기 상향 조정

## 📷 스크린샷
https://github.com/user-attachments/assets/9d1114d1-c02c-41de-80d1-64892cd8f1fb


## 💬 리뷰 요구사항(선택)
> 바꾸고 싶은 부분이 있다면 알려주세요!

## 🏷️ 연관된 이슈 번호
> #21 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
