### PR TITLE
Fix: 편집 중 일때 위키 이름이 로그인 유저로 뜨는 현상 수정

### DIFF
--- a/components/wikiEdit/WikiEditForm.tsx
+++ b/components/wikiEdit/WikiEditForm.tsx
@@ -56,6 +56,7 @@ export default function WikiEditForm() {
   const getValue = async () => {
     try {
       const res = await getProfile(code as string);
+      console.log(res);
       setContentValue(res);
       setUserId(res?.id);
       setWikiUserName(res?.name);
@@ -114,7 +115,7 @@ export default function WikiEditForm() {
       </ModalComponent>
       <form className={styles.formContainer} onSubmit={handleSubmit}>
         <div className={styles.userActionContainer}>
-          <span className={styles.userName}>{user?.name}님의 위키</span>
+          <span className={styles.userName}>{wikiUserName}님의 위키</span>
           <div className={styles.buttonContainer}>
             <Link href={`/wiki/${code}`} className={`${styles.secondaryButton} button`}>
               취소

--- a/components/wikiEdit/WikiEditForm.tsx
+++ b/components/wikiEdit/WikiEditForm.tsx
@@ -56,7 +56,6 @@ export default function WikiEditForm() {
   const getValue = async () => {
     try {
       const res = await getProfile(code as string);
-      console.log(res);
       setContentValue(res);
       setUserId(res?.id);
       setWikiUserName(res?.name);


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 편집 중 일때 위키 이름이 로그인 유저로 뜨는 현상 수정

## 📝 작업 내용 설명
> 편집 중 일때 위키 이름이 로그인 유저로 뜨는 현상 수정

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 🏷️ 연관된 이슈 번호
> ex) 이슈 번호

## ✅ 체크리스트:
- [ ] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [ ] 나는 PR 전에 내 코드를 검토했습니다.
- [ ] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [ ] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
