### PR TITLE
Refactor - 랜딩 페이지에서 홈으로 이동할 때, 페이지 이동 시간 개선

### DIFF
--- a/apis/getHomeProfileList.ts
+++ b/apis/getHomeProfileList.ts
@@ -1,0 +1,40 @@
+import ProfileType, { ProfileCardData } from '@/types/types';
+import { getProfile } from './getProfile';
+
+const PAGE_SIZE = '8';
+
+export const getHomeProfileList = async (): Promise<ProfileCardData[] | undefined> => {
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/profiles?pageSize=${PAGE_SIZE}`);
+
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const ProfileCodeList = await response
+      .json()
+      .then(res => res.list.map((profile: Record<string, string>) => profile.code));
+
+    // 프로필 코드로 메인 페이지에 표출할 8개의 프로필을 서버에서 각각 받아와야 함
+    const profileDetailList = await Promise.all(
+      ProfileCodeList.map((code: string) => getProfile(code).then(result => result)),
+    );
+
+    // 제공된 API에서 Profile을 리스트로 조회하는 것과 하나를 조회 하는 것이 서로 다른 데이터를 주기 때문에
+    // 메인 페이지에서 상세 데이터를 가져와야 하고, 필요없는 데이터를 거르는 작업이 필요 했음
+    const result = profileDetailList.map((profileDetail: ProfileType) => {
+      // content, securityQuestion은 사용되지 않음
+      // delete는 타입 안정성이 떨어지며, 기존 객체의 불변성을 유지할 수 없기에 사이드 이펙트 발생 여지가 있기에 구조분해할당 사용
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { content, securityQuestion, ...restProfile } = profileDetail;
+      return {
+        ...restProfile,
+      };
+    });
+
+    return result;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (error) {
+    return undefined;
+  }
+};

--- a/components/home/ProfileList.module.scss
+++ b/components/home/ProfileList.module.scss
@@ -1,0 +1,36 @@
+@import '../../styles/variables';
+@import '../../styles/mixins';
+
+.cardListContainer {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  padding: 0 30px;
+  grid-gap: 20px;
+  min-height: 100dvh;
+
+  @include tablet {
+    grid-template-columns: repeat(1, 1fr);
+  }
+
+  & > div {
+    &:nth-child(4n-1),
+    &:nth-child(4n) {
+      flex-direction: row-reverse;
+    }
+
+    @include tablet {
+      &:nth-child(n) {
+        flex-direction: row;
+      }
+      &:nth-child(2n) {
+        flex-direction: row-reverse;
+      }
+    }
+
+    @include mobile {
+      &:nth-child(n) {
+        flex-direction: column;
+      }
+    }
+  }
+}

--- a/components/home/ProfileList.tsx
+++ b/components/home/ProfileList.tsx
@@ -1,0 +1,30 @@
+import styles from './ProfileList.module.scss';
+import ProfileCard from './ProfileCard';
+import { useEffect, useState } from 'react';
+import { ProfileCardData } from '@/types/types';
+import { getHomeProfileList } from '@/apis/getHomeProfileList';
+
+export default function ProfileList() {
+  const [profileList, setProfileList] = useState<ProfileCardData[]>([]);
+
+  useEffect(() => {
+    const getProfileList = async () => {
+      const result = await getHomeProfileList();
+      if (result) {
+        setProfileList(result);
+      }
+    };
+
+    getProfileList();
+  }, []);
+
+  return (
+    <section className={styles.cardListContainer}>
+      {profileList?.map((profile, index) => {
+        // ProfileCard에서 id는 사용되지 않음
+        const { id, ...restProfile } = profile;
+        return <ProfileCard key={id} profile={restProfile} index={index} />;
+      })}
+    </section>
+  );
+}

--- a/pages/home/Home.module.scss
+++ b/pages/home/Home.module.scss
@@ -57,37 +57,3 @@
     color: $wiki-highlight;
   }
 }
-
-.cardListContainer {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  padding: 0 30px;
-  grid-gap: 20px;
-  min-height: 100dvh;
-
-  @include tablet {
-    grid-template-columns: repeat(1, 1fr);
-  }
-
-  & > div {
-    &:nth-child(4n-1),
-    &:nth-child(4n) {
-      flex-direction: row-reverse;
-    }
-
-    @include tablet {
-      &:nth-child(n) {
-        flex-direction: row;
-      }
-      &:nth-child(2n) {
-        flex-direction: row-reverse;
-      }
-    }
-
-    @include mobile {
-      &:nth-child(n) {
-        flex-direction: column;
-      }
-    }
-  }
-}

--- a/pages/home/Home.module.scss
+++ b/pages/home/Home.module.scss
@@ -3,7 +3,7 @@
 
 .homeContainer {
   display: flex;
-  min-height: calc(100vh - $header-height);
+  min-height: calc(100dvh - $header-height);
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -63,6 +63,7 @@
   grid-template-columns: repeat(2, 1fr);
   padding: 0 30px;
   grid-gap: 20px;
+  min-height: 100dvh;
 
   @include tablet {
     grid-template-columns: repeat(1, 1fr);

--- a/pages/home/index.tsx
+++ b/pages/home/index.tsx
@@ -1,80 +1,26 @@
 import ProfileCard from '@/components/home/ProfileCard';
-import ProfileType, { ProfileCardData } from '@/types/types';
+import { ProfileCardData } from '@/types/types';
 import styles from './Home.module.scss';
 import classNames from 'classnames';
-import { GetServerSideProps } from 'next';
 import { Bounce, Fade, JackInTheBox } from 'react-awesome-reveal';
-import { getProfile } from '@/apis/getProfile';
 import Footer from '@/components/@shared/footer/Footer';
+import { useEffect, useState } from 'react';
+import { getHomeProfileList } from '@/apis/getHomeProfileList';
 
-interface HomeProps {
-  profileList: ProfileCardData[];
-}
+export default function Home() {
+  const [profileList, setProfileList] = useState<ProfileCardData[]>([]);
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  let profileList = null;
-  try {
-    const query = new URLSearchParams({
-      pageSize: '8',
-    });
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/profiles?${query}`);
-    const ProfileCodeList = await response
-      .json()
-      .then(res => res.list.map((profile: Record<string, string>) => profile.code));
-
-    const profileDetailList = await Promise.all(
-      ProfileCodeList.map((code: string) => getProfile(code).then(result => result)),
-    );
-
-    // 부트캠프에서 제공하는 API에서 Profile을 리스트로 조회하는 것과 하나를 조회 하는 것이 서로 다른 데이터를 주기 때문에
-    // 메인 페이지에서 상세 데이터를 가져와야 하고, 필요없는 데이터를 거르는 작업이 필요 했음
-    const result = profileDetailList.map((profileDetail: ProfileType) => {
-      // content, securityQuestion은 사용되지 않음
-      const {
-        id,
-        birthday,
-        bloodType,
-        city,
-        code,
-        family,
-        image,
-        job,
-        mbti,
-        name,
-        nationality,
-        nickname,
-        sns,
-        updatedAt,
-      } = profileDetail;
-      return {
-        id,
-        birthday,
-        bloodType,
-        city,
-        code,
-        family,
-        image,
-        job,
-        mbti,
-        name,
-        nationality,
-        nickname,
-        sns,
-        updatedAt,
-      };
-    });
-
-    profileList = result;
-  } catch {
-    return {
-      notFound: true,
+  useEffect(() => {
+    const getProfileList = async () => {
+      const result = await getHomeProfileList();
+      if (result) {
+        setProfileList(result);
+      }
     };
-  }
 
-  return { props: { profileList } };
-};
+    getProfileList();
+  }, []);
 
-export default function Home({ profileList }: HomeProps) {
   return (
     <>
       <div className={styles.homeContainer}>

--- a/pages/home/index.tsx
+++ b/pages/home/index.tsx
@@ -1,26 +1,10 @@
-import ProfileCard from '@/components/home/ProfileCard';
-import { ProfileCardData } from '@/types/types';
 import styles from './Home.module.scss';
 import classNames from 'classnames';
 import { Bounce, Fade, JackInTheBox } from 'react-awesome-reveal';
 import Footer from '@/components/@shared/footer/Footer';
-import { useEffect, useState } from 'react';
-import { getHomeProfileList } from '@/apis/getHomeProfileList';
+import ProfileList from '@/components/home/ProfileList';
 
 export default function Home() {
-  const [profileList, setProfileList] = useState<ProfileCardData[]>([]);
-
-  useEffect(() => {
-    const getProfileList = async () => {
-      const result = await getHomeProfileList();
-      if (result) {
-        setProfileList(result);
-      }
-    };
-
-    getProfileList();
-  }, []);
-
   return (
     <>
       <div className={styles.homeContainer}>
@@ -44,13 +28,7 @@ export default function Home() {
             </p>
           </JackInTheBox>
         </section>
-        <section className={styles.cardListContainer}>
-          {profileList?.map((profile, index) => {
-            // ProfileCard에서 id는 사용되지 않음
-            const { id, ...restProfile } = profile;
-            return <ProfileCard key={id} profile={restProfile} index={index} />;
-          })}
-        </section>
+        <ProfileList />
       </div>
       <Footer />
     </>

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useValidForm, ValidationConfig } from '@/hooks/useValidForm';
 import ValidInput from '@/components/@shared/input/ValidInput';
 import { useAuth } from '@/contexts/AuthProvider';
@@ -20,7 +20,7 @@ const loginValidationConfig: ValidationConfig = {
 export default function LogInPage() {
   const { logIn } = useAuth();
 
-  const { register, errors, handleSubmit } = useValidForm({ validationConfig: loginValidationConfig });
+  const { register, errors, handleSubmit, setValue } = useValidForm({ validationConfig: loginValidationConfig });
 
   const handleFormSubmit = async (formData: FieldValues) => {
     if (formData.email && formData.password) {
@@ -28,6 +28,12 @@ export default function LogInPage() {
       await logIn({ email, password });
     }
   };
+
+  useEffect(() => {
+    // 테스트 계정 미리 입력을 위한 useEffect
+    setValue('email', process.env.NEXT_PUBLIC_TEST_ACCOUNT_ID);
+    setValue('password', process.env.NEXT_PUBLIC_TEST_ACCOUNT_PW);
+  }, []);
 
   return (
     <main className={'auth-container'}>


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 랜딩 페이지에서 홈으로 이동할 때, 페이지 이동 시간 개선

## 📝 작업 내용 설명
- 랜딩 페이지에서 홈으로 이동할 때, 페이지 이동 시간을 개선했습니다.
  - 홈 페이지에서 getServerSideProps로 인해 Link 태그의 prefetch가 작동하지 않아,
  페이지 로드 시간이 오래 걸리는 것이 원인이었습니다. 
  - 이때문에 getServerSideProps를 제거하고 useEffect로 데이터를 패치하도록 하여,
  홈 페이지는 랜딩 페이지에서 Link 태그가 뷰포트에 나타날 때 prefetch 되도록하여 페이지 전환 속도를 높였습니다. 
- 로그인 페이지에 테스트 계정을 미리 입력해두었습니다.

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/2c700cbe-afac-48de-ad5d-5aff35d11615)

<img width="472" alt="image" src="https://github.com/user-attachments/assets/9336b74a-98b0-4d10-883f-c67c105fd6bc">

## 💬 리뷰 요구사항(선택)
> 버그나 개선이 필요한 부분이 있다면 알려주세요.

## 🏷️ 연관된 이슈 번호
[#99 랜딩 페이지에서 홈으로 이동할 때, 페이지 이동 시간 개선](#99)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
